### PR TITLE
Add support for RGB brightness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 .gcc-flags.json
 .travis.yml
 lib/
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json

--- a/anavi-light-controller-sw/anavi-light-controller-sw.ino
+++ b/anavi-light-controller-sw/anavi-light-controller-sw.ino
@@ -37,6 +37,9 @@ bool power = false;
 int lightRed = 255;
 int lightGreen = 255;
 int lightBlue = 255;
+int currentRed = 255;
+int currentGreen = 255;
+int currentBlue = 255;
 int brightnessLevel = 255;
 
 unsigned long sensorPreviousMillis = 0;
@@ -369,9 +372,10 @@ void mqttCallback(char* topic, byte* payload, unsigned int length)
             const int brightness = data["brightness"];
             if ( (0 <= brightness) && (255 >= brightness) )
             {
-                setBrightness(brightness);
+                currentBrightness = brightness;
             }
         }
+        calculateBrightness(brightness);
         if (data.containsKey("state"))
         {
             power = data["state"] == "ON";
@@ -408,13 +412,12 @@ void mqttCallback(char* topic, byte* payload, unsigned int length)
     }
 }
 
-void setBrightness(unsigned int inputBrightness)
+void calculateBrightness()
 {
     unsigned int maximumBrightness = 255;
-    lightRed = (lightRed * inputBrightness) / maximumBrightness;
-    lightBlue = (lightBlue * inputBrightness) / maximumBrightness;
-    lightGreen = (lightGreen * inputBrightness) / maximumBrightness;
-    brightnessLevel = inputBrightness;
+    lightRed = (currentRed * brightnessLevel) / maximumBrightness;
+    lightBlue = (currentBlue * brightnessLevel) / maximumBrightness;
+    lightGreen = (currentGreen * brightnessLevel) / maximumBrightness;
 }
 
 void calculateMachineId()

--- a/anavi-light-controller-sw/anavi-light-controller-sw.ino
+++ b/anavi-light-controller-sw/anavi-light-controller-sw.ino
@@ -362,9 +362,9 @@ void mqttCallback(char* topic, byte* payload, unsigned int length)
             const int r = data["color"]["r"];
             const int g = data["color"]["g"];
             const int b = data["color"]["b"];
-            lightRed = ((0 <= r) && (255 >= r)) ? r : 0;
-            lightGreen = ((0 <= g) && (255 >= g)) ? g : 0;
-            lightBlue = ((0 <= b) && (255 >= b)) ? b : 0;
+            currentRed = ((0 <= r) && (255 >= r)) ? r : 0;
+            currentGreen = ((0 <= g) && (255 >= g)) ? g : 0;
+            curentBlue = ((0 <= b) && (255 >= b)) ? b : 0;
             // power = ( (0 < lightRed) || (0 < lightGreen) || (0 < lightBlue) );
         }
         if (data.containsKey("brightness"))
@@ -372,10 +372,10 @@ void mqttCallback(char* topic, byte* payload, unsigned int length)
             const int brightness = data["brightness"];
             if ( (0 <= brightness) && (255 >= brightness) )
             {
-                currentBrightness = brightness;
+                brightnessLevel = brightness;
             }
         }
-        calculateBrightness(brightness);
+        calculateBrightness();
         if (data.containsKey("state"))
         {
             power = data["state"] == "ON";
@@ -473,11 +473,9 @@ void publishState()
     json["brightness"] = brightnessLevel;
 
     JsonObject& color = json.createNestedObject("color");
-    color["r"] = power ? lightRed : 0;
-    color["g"] = power ? lightGreen : 0;
-    color["b"] = power ? lightBlue : 0;
-
-    json["brightness"] = brightnessLevel;
+    color["r"] = power ? currentRed : 0;
+    color["g"] = power ? currentGreen : 0;
+    color["b"] = power ? currentBlue : 0;
 
     json.printTo((char*)payload, json.measureLength() + 1);
 


### PR DESCRIPTION
First off, I understand there's some sizable changes in here, so let me know if you'd prefer not to merge them in. Also, this is the first C++ I've written in years so it's probably not the cleanest.

---

So this PR changes a few things with the end result that it supports "real" RGB brightness. That is, setting RGB color of 255,0,0 and brightness of 128 will result in half-brightness red, rather than resetting to white.

As part of that, this also fixes #4 by including the brightness along with the "real" color (that is the full brightness color, not what's actually on the LEDs) in the state payload.

---

**As far as I can tell**, this change should be fully backwards-compatible with existing firmware and with the demo site, but this change makes Home Assistant (and MQTT) integration much cleaner.