### PR TITLE
[home-assistant] Implement simple rainbow effects

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -14,6 +14,7 @@ src_dir = anavi-light-controller-sw
 [env:esp01_1m]
 platform = espressif8266
 board = esp01_1m
+monitor_speed = 115200
 framework = arduino
 lib_deps =
     WiFiManager


### PR DESCRIPTION
Also added switch_transition effect for smooth changing to manually selected color

Usage:
```
light:
  - platform: mqtt
    schema: json
    name: "kitchen_rgb"
    state_topic: "stat/a221b204e06b690772884e78d31691e/color"
    command_topic: "cmnd/a221b204e06b690772884e78d31691e/color"
    brightness: true
    rgb: true
    effect: true
    effect_list:
      - rainbow1
      - rainbow2
      - rainbow3
      - rainbow4
      - switch_transition
      - none
```