### PR TITLE
Updated publishState() to publish (power) state as a JSON payload

### DIFF
--- a/anavi-light-controller-sw/anavi-light-controller-sw.ino
+++ b/anavi-light-controller-sw/anavi-light-controller-sw.ino
@@ -993,6 +993,10 @@ void publishState()
     DynamicJsonDocument json(1024);
     const char* state = power ? "ON" : "OFF";
     json["state"] = state;
+
+    char stat_power_payload[150];
+    serializeJson(json, stat_power_payload);
+
     json["brightness"] = brightnessLevel;
     json["effect"] = effect;
 
@@ -1021,8 +1025,9 @@ void publishState()
     Serial.print("[");
     Serial.print(stat_power_topic);
     Serial.print("] ");
-    Serial.println(state);
-    mqttClient.publish(stat_power_topic, state, true);
+    Serial.println(stat_power_payload);
+
+    mqttClient.publish(stat_power_topic, stat_power_payload, true);
 }
 
 void publishSensorData(const char* subTopic, const char* key, const float value)


### PR DESCRIPTION
When turning on/turning off the light strip, the following error is logged in Home Assistant:

```
2020-01-11 21:04:59 ERROR (MainThread) [homeassistant.util.logging] Exception in state_received when handling msg on 'stat/292772005a57d4c99853251bb427606/power': 'ON'
Traceback (most recent call last):
  File "/srv/homeassistant/lib/python3.7/site-packages/homeassistant/components/mqtt/light/schema_json.py", line 245, in state_received
    values = json.loads(msg.payload)
  File "/usr/lib/python3.7/json/__init__.py", line 348, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.7/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.7/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

I believe that this is due to `publishState()` publishing either a plain `ON` or `OFF` to the `stat/{machineId}/power` topic. 

As a result `publishState()` has been updated publish to the `stat/{machineId}/power` topic with a JSON payload.