### PR TITLE
more fine-grained temp change check

### DIFF
--- a/anavi-light-controller-sw/anavi-light-controller-sw.ino
+++ b/anavi-light-controller-sw/anavi-light-controller-sw.ino
@@ -1069,7 +1069,7 @@ void handleHTU21D()
 {
     // Check if temperature has changed
     const float tempTemperature = htu.readTemperature();
-    if (1 <= abs(tempTemperature - sensorTemperature))
+    if (0.1 <= fabs(tempTemperature - sensorTemperature))
     {
         // Print new temprature value
         sensorTemperature = tempTemperature;


### PR DESCRIPTION
Hi

I noticed that the reporting accuracy of the HTU21D sensor for temperature was very low. Indeed it would only report when temperature changes of more than 1°C occurred. Since the sensor itself is capable of measuring at a higher accuracy, I've created this PR that picks up changes of more than 0.1°C. This gives a much smoother experience e.g. when using in Home Assistant

Cheers